### PR TITLE
Fix OIDC metadata refresh on stale or invalid signatures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -899,17 +899,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
-name = "chacha20"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.3.0",
- "rand_core 0.10.1",
-]
-
-[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1047,15 +1036,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cpufeatures"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "crabcakes"
 version = "0.0.1"
 dependencies = [
@@ -1080,7 +1060,7 @@ dependencies = [
  "num_cpus",
  "openidconnect",
  "quick-xml",
- "rand 0.10.1",
+ "rand 0.9.4",
  "regex",
  "reqwest",
  "rustls 0.23.40",
@@ -1221,7 +1201,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "curve25519-dalek-derive",
  "digest",
  "fiat-crypto",
@@ -1895,7 +1875,6 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
- "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -3241,17 +3220,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
-dependencies = [
- "chacha20",
- "getrandom 0.4.2",
- "rand_core 0.10.1",
-]
-
-[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3288,12 +3256,6 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "redox_syscall"
@@ -4116,7 +4078,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "digest",
 ]
 
@@ -4127,7 +4089,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "digest",
 ]
 

--- a/src/auth/oauth.rs
+++ b/src/auth/oauth.rs
@@ -1,11 +1,12 @@
 //! OIDC/OAuth2 client with PKCE support
 
-use std::{sync::Arc, time::Duration};
+use std::{future::Future, pin::Pin, sync::Arc, time::Duration};
 
+use chrono::{DateTime, Utc};
 use openidconnect::{
-    AuthenticationFlow, AuthorizationCode, ClientId, CsrfToken, IssuerUrl, Nonce,
-    PkceCodeChallenge, PkceCodeVerifier, RedirectUrl, Scope, TokenResponse,
-    core::{CoreClient, CoreProviderMetadata, CoreResponseType},
+    AuthenticationFlow, AuthorizationCode, ClaimsVerificationError, ClientId, CsrfToken, IssuerUrl,
+    Nonce, PkceCodeChallenge, PkceCodeVerifier, RedirectUrl, Scope, TokenResponse,
+    core::{CoreClient, CoreIdToken, CoreIdTokenClaims, CoreProviderMetadata, CoreResponseType},
 };
 use reqwest;
 use tokio::sync::RwLock;
@@ -14,12 +15,41 @@ use tracing::{debug, error, trace};
 use crate::db::DBService;
 use crate::error::CrabCakesError;
 
+const OIDC_METADATA_MAX_AGE: chrono::Duration = chrono::Duration::hours(24);
+
+type ProviderMetadataDiscoveryResult =
+    Result<CoreProviderMetadata, openidconnect::DiscoveryError<reqwest::Error>>;
+type ProviderMetadataDiscoveryFuture =
+    Pin<Box<dyn Future<Output = ProviderMetadataDiscoveryResult> + Send>>;
+type ProviderMetadataDiscoverer =
+    Arc<dyn Fn(IssuerUrl, reqwest::Client) -> ProviderMetadataDiscoveryFuture + Send + Sync>;
+
+#[derive(Clone)]
+struct CachedProviderMetadata {
+    provider_metadata: CoreProviderMetadata,
+    fetched_at: DateTime<Utc>,
+}
+
+impl CachedProviderMetadata {
+    fn is_fresh_at(&self, now: DateTime<Utc>) -> bool {
+        metadata_is_fresh_at(self.fetched_at, now)
+    }
+}
+
+fn metadata_is_fresh_at(fetched_at: DateTime<Utc>, now: DateTime<Utc>) -> bool {
+    now.signed_duration_since(fetched_at) < OIDC_METADATA_MAX_AGE
+}
+
+fn default_provider_metadata_discoverer() -> ProviderMetadataDiscoverer {
+    Arc::new(|issuer_url, http_client| Box::pin(run_discovery(issuer_url, http_client)))
+}
+
 async fn run_discovery(
-    issuer_url: &IssuerUrl,
+    issuer_url: IssuerUrl,
     http_client: reqwest::Client,
 ) -> Result<CoreProviderMetadata, openidconnect::DiscoveryError<reqwest::Error>> {
     CoreProviderMetadata::discover_async(
-        issuer_url.clone(),
+        issuer_url,
         &(move |http_request: http::Request<Vec<u8>>| {
             let http_client = http_client.clone();
             async move {
@@ -46,12 +76,13 @@ async fn run_discovery(
 
 /// OAuth client for OIDC authentication with PKCE
 pub struct OAuthClient {
-    provider_metadata: Arc<RwLock<Option<CoreProviderMetadata>>>,
+    provider_metadata: Arc<RwLock<Option<CachedProviderMetadata>>>,
     client_id: ClientId,
     redirect_uri: RedirectUrl,
     db: Arc<DBService>,
     http_client: reqwest::Client,
     issuer_url: IssuerUrl,
+    provider_metadata_discoverer: ProviderMetadataDiscoverer,
 }
 
 impl OAuthClient {
@@ -72,16 +103,21 @@ impl OAuthClient {
         let issuer_url = IssuerUrl::new(discovery_url.to_string())
             .map_err(|e| CrabCakesError::other(&format!("Invalid OIDC issuer URL: {}", e)))?;
 
+        let provider_metadata_discoverer = default_provider_metadata_discoverer();
         let http_client_clone = http_client.clone();
         // TODO: make this a delayed task that can retry
-        let provider_metadata = match run_discovery(&issuer_url, http_client_clone).await {
-            Ok(pm) => Arc::new(RwLock::new(Some(pm))),
-            Err(err) => {
-                error!(error=%err, "Failed to run OIDC discovery");
-                // TODO: this should spawn a task to retry discovery every 30 seconds
-                Arc::new(RwLock::new(None))
-            }
-        };
+        let provider_metadata =
+            match provider_metadata_discoverer(issuer_url.clone(), http_client_clone).await {
+                Ok(pm) => Arc::new(RwLock::new(Some(CachedProviderMetadata {
+                    provider_metadata: pm,
+                    fetched_at: Utc::now(),
+                }))),
+                Err(err) => {
+                    error!(error=%err, "Failed to run OIDC discovery");
+                    // TODO: this should spawn a task to retry discovery every 30 seconds
+                    Arc::new(RwLock::new(None))
+                }
+            };
 
         let redirect_url = RedirectUrl::new(redirect_uri.to_string()).map_err(|e| {
             CrabCakesError::OidcDiscovery(format!("Invalid OIDC redirect URI: {}", e))
@@ -94,24 +130,88 @@ impl OAuthClient {
             db,
             http_client,
             issuer_url,
+            provider_metadata_discoverer,
         })
     }
 
-    pub async fn update_provider_metadata(&self) -> Result<CoreProviderMetadata, CrabCakesError> {
-        let existing_pm = self.provider_metadata.read().await.clone();
-        match existing_pm {
-            Some(provider_metadata) => Ok(provider_metadata.clone()),
-            None => {
-                let pm = run_discovery(&self.issuer_url, self.http_client.clone())
-                    .await
-                    .map_err(|err| {
-                        error!(error=?err, "Failed to run OIDC discovery");
-                        CrabCakesError::from(err)
-                    })?;
-                self.provider_metadata.write().await.replace(pm.clone());
-                Ok(pm)
+    async fn get_provider_metadata(&self) -> Result<CoreProviderMetadata, CrabCakesError> {
+        if let Some(cached_provider_metadata) = self.provider_metadata.read().await.clone() {
+            if cached_provider_metadata.is_fresh_at(Utc::now()) {
+                return Ok(cached_provider_metadata.provider_metadata);
             }
+
+            debug!("OIDC provider metadata is older than 24 hours; refreshing");
         }
+
+        self.refresh_provider_metadata().await
+    }
+
+    async fn refresh_provider_metadata(&self) -> Result<CoreProviderMetadata, CrabCakesError> {
+        let pm = self.provider_metadata_discoverer.as_ref()(
+            self.issuer_url.clone(),
+            self.http_client.clone(),
+        )
+        .await
+        .map_err(|err| {
+            error!(error=?err, "Failed to run OIDC discovery");
+            CrabCakesError::from(err)
+        })?;
+
+        self.provider_metadata
+            .write()
+            .await
+            .replace(CachedProviderMetadata {
+                provider_metadata: pm.clone(),
+                fetched_at: Utc::now(),
+            });
+        Ok(pm)
+    }
+
+    fn validate_id_token_claims<'a>(
+        &self,
+        provider_metadata: CoreProviderMetadata,
+        id_token: &'a CoreIdToken,
+        nonce: &Nonce,
+    ) -> Result<&'a CoreIdTokenClaims, ClaimsVerificationError> {
+        let client = CoreClient::from_provider_metadata(
+            provider_metadata,
+            self.client_id.clone(),
+            None, // No client secret (public client with PKCE)
+        )
+        .set_redirect_uri(self.redirect_uri.clone());
+
+        id_token.claims(&client.id_token_verifier(), nonce)
+    }
+
+    async fn validate_with_metadata_refresh<T>(
+        &self,
+        provider_metadata: CoreProviderMetadata,
+        validate: impl Fn(CoreProviderMetadata) -> Result<T, ClaimsVerificationError>,
+    ) -> Result<T, CrabCakesError> {
+        match validate(provider_metadata) {
+            Ok(value) => Ok(value),
+            Err(err) if Self::is_signature_validation_error(&err) => {
+                error!(
+                    error = %err,
+                    "ID token signature validation failed; refreshing OIDC provider metadata and retrying"
+                );
+                let refreshed_provider_metadata = self.refresh_provider_metadata().await?;
+                validate(refreshed_provider_metadata).map_err(|retry_err| {
+                    CrabCakesError::other(&format!(
+                        "ID token validation failed after OIDC metadata refresh: {}",
+                        retry_err
+                    ))
+                })
+            }
+            Err(err) => Err(CrabCakesError::other(&format!(
+                "ID token validation failed: {}",
+                err
+            ))),
+        }
+    }
+
+    fn is_signature_validation_error(err: &ClaimsVerificationError) -> bool {
+        matches!(err, ClaimsVerificationError::SignatureVerification(_))
     }
 
     /// Generate authorization URL with PKCE challenge
@@ -119,10 +219,7 @@ impl OAuthClient {
     pub async fn generate_auth_url(&self) -> Result<(String, String), CrabCakesError> {
         let (pkce_challenge, pkce_verifier) = PkceCodeChallenge::new_random_sha256();
 
-        let provider_metadata = match self.provider_metadata.read().await.as_ref() {
-            Some(val) => val.clone(),
-            None => self.update_provider_metadata().await?,
-        };
+        let provider_metadata = self.get_provider_metadata().await?;
         let client = CoreClient::from_provider_metadata(
             provider_metadata,
             self.client_id.clone(),
@@ -183,12 +280,9 @@ impl OAuthClient {
 
         // Exchange code for tokens
 
-        let provider_metadata = match self.provider_metadata.read().await.as_ref() {
-            Some(val) => val.clone(),
-            None => self.update_provider_metadata().await?,
-        };
+        let provider_metadata = self.get_provider_metadata().await?;
         let client = CoreClient::from_provider_metadata(
-            provider_metadata,
+            provider_metadata.clone(),
             self.client_id.clone(),
             None, // No client secret (public client with PKCE)
         )
@@ -267,9 +361,11 @@ impl OAuthClient {
             .ok_or_else(|| CrabCakesError::other(&"No ID token in response".to_string()))?;
 
         let nonce = Nonce::new(pkce_state.nonce.clone());
-        let claims = id_token
-            .claims(&client.id_token_verifier(), &nonce)
-            .map_err(|e| CrabCakesError::other(&format!("ID token validation failed: {}", e)))?;
+        let claims = self
+            .validate_with_metadata_refresh(provider_metadata, |metadata| {
+                self.validate_id_token_claims(metadata, id_token, &nonce)
+            })
+            .await?;
 
         // Extract user info
         let user_email = claims
@@ -286,5 +382,203 @@ impl OAuthClient {
         self.db.delete_pkce_state(state).await?;
 
         Ok((user_email, user_id))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+
+    use openidconnect::{
+        AuthUrl, JsonWebKeySetUrl, ResponseTypes, SignatureVerificationError,
+        core::{CoreJwsSigningAlgorithm, CoreSubjectIdentifierType},
+    };
+
+    use super::*;
+    use crate::db::{DBService, initialize_in_memory_database};
+
+    fn test_provider_metadata(issuer: &str) -> CoreProviderMetadata {
+        CoreProviderMetadata::new(
+            IssuerUrl::new(issuer.to_string()).expect("issuer URL should be valid"),
+            AuthUrl::new(format!("{issuer}/auth")).expect("auth URL should be valid"),
+            JsonWebKeySetUrl::new(format!("{issuer}/jwks")).expect("JWKS URL should be valid"),
+            vec![ResponseTypes::new(vec![CoreResponseType::Code])],
+            vec![CoreSubjectIdentifierType::Public],
+            vec![CoreJwsSigningAlgorithm::RsaSsaPkcs1V15Sha256],
+            Default::default(),
+        )
+    }
+
+    fn discoverer_returning(
+        provider_metadata: CoreProviderMetadata,
+        calls: Arc<AtomicUsize>,
+    ) -> ProviderMetadataDiscoverer {
+        Arc::new(move |_issuer_url, _http_client| {
+            calls.fetch_add(1, Ordering::SeqCst);
+            let provider_metadata = provider_metadata.clone();
+            Box::pin(async move { Ok(provider_metadata) })
+        })
+    }
+
+    async fn test_client(
+        provider_metadata: Option<CachedProviderMetadata>,
+        provider_metadata_discoverer: ProviderMetadataDiscoverer,
+    ) -> OAuthClient {
+        let db = Arc::new(DBService::new(Arc::new(
+            initialize_in_memory_database().await,
+        )));
+        let http_client = reqwest::ClientBuilder::new()
+            .redirect(reqwest::redirect::Policy::none())
+            .timeout(Duration::from_secs(5))
+            .build()
+            .expect("HTTP client should build");
+
+        OAuthClient {
+            provider_metadata: Arc::new(RwLock::new(provider_metadata)),
+            client_id: ClientId::new("test-client".to_string()),
+            redirect_uri: RedirectUrl::new("https://app.example/oauth2/callback".to_string())
+                .expect("redirect URI should be valid"),
+            db,
+            http_client,
+            issuer_url: IssuerUrl::new("https://issuer.example".to_string())
+                .expect("issuer URL should be valid"),
+            provider_metadata_discoverer,
+        }
+    }
+
+    #[test]
+    fn metadata_younger_than_24_hours_is_fresh() {
+        let now = Utc::now();
+
+        assert!(metadata_is_fresh_at(now - chrono::Duration::hours(23), now));
+    }
+
+    #[test]
+    fn metadata_24_hours_old_is_stale() {
+        let now = Utc::now();
+
+        assert!(!metadata_is_fresh_at(
+            now - chrono::Duration::hours(24),
+            now
+        ));
+    }
+
+    #[tokio::test]
+    async fn get_provider_metadata_reuses_fresh_cached_metadata() {
+        let cached_metadata = test_provider_metadata("https://cached.example");
+        let refresh_metadata = test_provider_metadata("https://refresh.example");
+        let calls = Arc::new(AtomicUsize::new(0));
+        let client = test_client(
+            Some(CachedProviderMetadata {
+                provider_metadata: cached_metadata.clone(),
+                fetched_at: Utc::now(),
+            }),
+            discoverer_returning(refresh_metadata, calls.clone()),
+        )
+        .await;
+
+        let provider_metadata = client
+            .get_provider_metadata()
+            .await
+            .expect("fresh metadata should be returned");
+
+        assert_eq!(provider_metadata.issuer(), cached_metadata.issuer());
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn get_provider_metadata_refreshes_stale_cached_metadata() {
+        let cached_metadata = test_provider_metadata("https://cached.example");
+        let refresh_metadata = test_provider_metadata("https://refresh.example");
+        let calls = Arc::new(AtomicUsize::new(0));
+        let client = test_client(
+            Some(CachedProviderMetadata {
+                provider_metadata: cached_metadata,
+                fetched_at: Utc::now() - chrono::Duration::hours(24),
+            }),
+            discoverer_returning(refresh_metadata.clone(), calls.clone()),
+        )
+        .await;
+
+        let provider_metadata = client
+            .get_provider_metadata()
+            .await
+            .expect("stale metadata should be refreshed");
+
+        assert_eq!(provider_metadata.issuer(), refresh_metadata.issuer());
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn signature_validation_error_refreshes_metadata_and_retries_once() {
+        let initial_metadata = test_provider_metadata("https://initial.example");
+        let refresh_metadata = test_provider_metadata("https://refresh.example");
+        let refresh_calls = Arc::new(AtomicUsize::new(0));
+        let validation_attempts = Arc::new(AtomicUsize::new(0));
+        let client = test_client(
+            Some(CachedProviderMetadata {
+                provider_metadata: initial_metadata.clone(),
+                fetched_at: Utc::now(),
+            }),
+            discoverer_returning(refresh_metadata.clone(), refresh_calls.clone()),
+        )
+        .await;
+
+        let result = client
+            .validate_with_metadata_refresh(initial_metadata.clone(), {
+                let validation_attempts = validation_attempts.clone();
+                move |provider_metadata| {
+                    let attempt = validation_attempts.fetch_add(1, Ordering::SeqCst) + 1;
+                    if attempt == 1 {
+                        assert_eq!(provider_metadata.issuer(), initial_metadata.issuer());
+                        Err(ClaimsVerificationError::SignatureVerification(
+                            SignatureVerificationError::NoMatchingKey,
+                        ))
+                    } else {
+                        assert_eq!(provider_metadata.issuer(), refresh_metadata.issuer());
+                        Ok(())
+                    }
+                }
+            })
+            .await;
+
+        assert!(result.is_ok());
+        assert_eq!(validation_attempts.load(Ordering::SeqCst), 2);
+        assert_eq!(refresh_calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn non_signature_validation_error_does_not_refresh_metadata() {
+        let initial_metadata = test_provider_metadata("https://initial.example");
+        let refresh_metadata = test_provider_metadata("https://refresh.example");
+        let refresh_calls = Arc::new(AtomicUsize::new(0));
+        let validation_attempts = Arc::new(AtomicUsize::new(0));
+        let client = test_client(
+            Some(CachedProviderMetadata {
+                provider_metadata: initial_metadata.clone(),
+                fetched_at: Utc::now(),
+            }),
+            discoverer_returning(refresh_metadata, refresh_calls.clone()),
+        )
+        .await;
+
+        let result: Result<(), CrabCakesError> = client
+            .validate_with_metadata_refresh(initial_metadata, {
+                let validation_attempts = validation_attempts.clone();
+                move |_provider_metadata| {
+                    validation_attempts.fetch_add(1, Ordering::SeqCst);
+                    Err(ClaimsVerificationError::InvalidNonce(
+                        "bad nonce".to_string(),
+                    ))
+                }
+            })
+            .await;
+
+        assert!(result.is_err());
+        assert_eq!(validation_attempts.load(Ordering::SeqCst), 1);
+        assert_eq!(refresh_calls.load(Ordering::SeqCst), 0);
     }
 }


### PR DESCRIPTION
## Summary
- Cache discovered OIDC provider metadata with a fetch timestamp.
- Refresh metadata automatically when it is older than 24 hours.
- Retry ID token claim validation once after a signature verification failure.
- Add focused tests for freshness checks, stale refresh, and retry behavior.

## Testing
- `cargo test auth::oauth::tests`
- `just check`