### PR TITLE
Validate credential secret length end to end

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,10 +8,12 @@
     "build-ts": "swc src/js --delete-dir-on-start --strip-leading-paths --out-dir target/js/ *.ts",
     "build": "pnpm build-ts && node build-js.js",
     "test": "pnpm run build && node --test tests/js/*.test.mjs",
+    "test:playwright": "pnpm run build && playwright test",
     "lint:css": "stylelint 'static/css/**/*.css'",
     "lint": "pnpm run lint:css"
   },
   "devDependencies": {
+    "@playwright/test": "^1.60.0",
     "@swc/cli": "^0.7.10",
     "@swc/core": "^1.15.24",
     "esbuild": "^0.25.12",

--- a/playwright.config.mjs
+++ b/playwright.config.mjs
@@ -1,0 +1,11 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+    testDir: './tests/playwright',
+    outputDir: './target/playwright-results',
+    reporter: 'list',
+    use: {
+        ...devices['Desktop Chrome'],
+        trace: 'on-first-retry',
+    },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,9 @@ importers:
         specifier: ^3.1026.0
         version: 3.1026.0
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.60.0
+        version: 1.60.0
       '@swc/cli':
         specifier: ^0.7.10
         version: 0.7.10(@swc/core@1.15.24)
@@ -582,6 +585,11 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@playwright/test@1.60.0':
+    resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@sindresorhus/is@5.6.0':
     resolution: {integrity: sha512-TV7t8GKYaJWsn00tFDqBw8+Uqmr8A0fRU1tvTQhyZzGv0sJCGRQL3JGMI3ucuKo3XIZdUP+Lx7/gh2t3lewy7g==}
@@ -1344,6 +1352,11 @@ packages:
     resolution: {integrity: sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==}
     engines: {node: '>= 14.17'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   get-stream@6.0.1:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
     engines: {node: '>=10'}
@@ -1653,6 +1666,16 @@ packages:
 
   piscina@4.9.2:
     resolution: {integrity: sha512-Fq0FERJWFEUpB4eSY59wSNwXD4RYqR+nR/WiEVcZW8IWfVBxJJafcgTEZDQo8k3w0sUarJ8RyVbbUF4GQ2LGbQ==}
+
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   postcss-resolve-nested-selector@0.1.6:
     resolution: {integrity: sha512-0sglIs9Wmkzbr8lQwEyIzlDOOC9bGmfVKcJTaxv3vMmd3uo4o4DerC3En0bnmgceeql9BfC8hRkp7cg0fjdVqw==}
@@ -2629,6 +2652,10 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
+  '@playwright/test@1.60.0':
+    dependencies:
+      playwright: 1.60.0
+
   '@sindresorhus/is@5.6.0': {}
 
   '@smithy/chunked-blob-reader-native@4.2.3':
@@ -3580,6 +3607,9 @@ snapshots:
 
   form-data-encoder@2.1.4: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   get-stream@6.0.1: {}
 
   glob-parent@5.1.2:
@@ -3832,6 +3862,14 @@ snapshots:
   piscina@4.9.2:
     optionalDependencies:
       '@napi-rs/nice': 1.1.1
+
+  playwright-core@1.60.0: {}
+
+  playwright@1.60.0:
+    dependencies:
+      playwright-core: 1.60.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss-resolve-nested-selector@0.1.6: {}
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -256,7 +256,10 @@ impl From<CrabCakesError> for Response<Full<Bytes>> {
 
         let mut res = Response::new(Full::new(Bytes::from(html)));
 
-        *res.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
+        *res.status_mut() = match err {
+            CrabCakesError::InvalidSecretLength => StatusCode::BAD_REQUEST,
+            _ => StatusCode::INTERNAL_SERVER_ERROR,
+        };
         (*res.headers_mut()).append(
             CONTENT_TYPE,
             HeaderValue::from_static(TEXT_HTML_UTF_8.as_ref()),

--- a/src/tests/request_handler_tests.rs
+++ b/src/tests/request_handler_tests.rs
@@ -5,6 +5,7 @@
 
 use secret_string::SecretString;
 
+use crate::error::CrabCakesError;
 use crate::logging::setup_test_logging;
 use crate::request_handler::RequestHandler;
 use crate::web::serde::{CredentialInfo, VacuumResult};
@@ -409,6 +410,31 @@ async fn test_api_create_credential_valid() {
 }
 
 #[tokio::test]
+async fn test_api_create_credential_rejects_invalid_secret_lengths() {
+    let handler = RequestHandler::new_test().await;
+
+    for secret in ["a".repeat(39), "a".repeat(41)] {
+        let result = handler
+            .api_create_credential("badsecret".to_string(), secret.into())
+            .await;
+
+        assert!(
+            matches!(result, Err(CrabCakesError::InvalidSecretLength)),
+            "should reject secret length before storing credential"
+        );
+    }
+
+    let creds = handler
+        .api_list_credentials()
+        .await
+        .expect("credentials should list");
+    assert!(
+        !creds.iter().any(|cred| cred.access_key_id == "badsecret"),
+        "invalid credential should not be stored"
+    );
+}
+
+#[tokio::test]
 async fn test_api_create_credential_duplicate() {
     let handler = RequestHandler::new_test().await;
 
@@ -450,6 +476,28 @@ async fn test_api_update_credential_existing() {
         .await;
 
     assert!(result.is_ok(), "Should update existing credential");
+}
+
+#[tokio::test]
+async fn test_api_update_credential_rejects_invalid_secret_lengths() {
+    let handler = RequestHandler::new_test().await;
+    let old_secret = "a".repeat(40);
+
+    handler
+        .api_create_credential("badupdateuser".to_string(), old_secret.into())
+        .await
+        .expect("Should create credential");
+
+    for secret in ["b".repeat(39), "b".repeat(41)] {
+        let result = handler
+            .api_update_credential("badupdateuser".to_string(), secret.into())
+            .await;
+
+        assert!(
+            matches!(result, Err(CrabCakesError::InvalidSecretLength)),
+            "should reject invalid secret length"
+        );
+    }
 }
 
 #[tokio::test]

--- a/src/web/handlers.rs
+++ b/src/web/handlers.rs
@@ -2062,6 +2062,21 @@ mod tests {
         assert!(body_str.contains("Test error"));
     }
 
+    #[tokio::test]
+    async fn test_invalid_secret_length_error_response_is_validation_failure() {
+        let response: Response<Full<Bytes>> = CrabCakesError::InvalidSecretLength.into();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+        let body_bytes = response
+            .into_body()
+            .collect()
+            .await
+            .expect("response body should collect")
+            .to_bytes();
+        let body_str = std::str::from_utf8(&body_bytes).expect("Body is not valid UTF-8");
+        assert!(body_str.contains("Invalid Secret Length"));
+    }
+
     // Allow Scenario Tests
 
     #[tokio::test]

--- a/templates/credential_form.html
+++ b/templates/credential_form.html
@@ -29,7 +29,7 @@ Crabcakes Admin{% endblock %}
                 characters)</label>
             <input type="password" id="secret-access-key"
                 name="secret-access-key"
-                minlength="40" maxlength="40" pattern=".{40}" required>
+                minlength="40" pattern=".{40}" required>
             <button type="button" id="generate-key-btn"
                 class="btn btn-secondary">
                 Generate Random Key

--- a/tests/playwright/credential-form.spec.mjs
+++ b/tests/playwright/credential-form.spec.mjs
@@ -1,0 +1,190 @@
+import { readFile } from 'node:fs/promises';
+
+import { expect, test } from '@playwright/test';
+
+const appOrigin = 'http://crabcakes.test';
+const credentialScript = await readFile(
+    new URL('../../static/js/credential-crud.js', import.meta.url),
+    'utf8',
+);
+const credentialTemplate = await readFile(
+    new URL('../../templates/credential_form.html', import.meta.url),
+    'utf8',
+);
+
+function credentialFormHtml({ edit = false } = {}) {
+    return `<!doctype html>
+<html lang="en">
+<body>
+    <form id="credential-form">
+        <input
+            type="text"
+            id="access-key-id"
+            name="access-key-id"
+            value="test-user"
+            ${edit ? 'readonly' : ''}
+            required
+        >
+        <input
+            type="password"
+            id="secret-access-key"
+            name="secret-access-key"
+            minlength="40"
+            pattern=".{40}"
+            required
+        >
+        <button type="button" id="generate-key-btn">Generate Random Key</button>
+        <button type="button" id="toggle-visibility-btn">Show/Hide</button>
+        <button type="submit">Save Credential</button>
+    </form>
+    <button type="button" id="delete-credential-btn" data-access-key-id="test-user">Delete</button>
+    <script>${credentialScript}</script>
+</body>
+</html>`;
+}
+
+async function openCredentialForm(page, { edit = false } = {}) {
+    const credentialRequests = [];
+
+    await page.route(`${appOrigin}/admin/api/csrf-token`, async (route) => {
+        await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({ csrf_token: 'csrf-token' }),
+        });
+    });
+
+    await page.route(/^http:\/\/crabcakes\.test\/admin\/api\/credentials(?:\/[^/]+)?$/, async (route) => {
+        const request = route.request();
+        credentialRequests.push({
+            method: request.method(),
+            url: request.url(),
+            headers: request.headers(),
+            body: JSON.parse(request.postData() ?? '{}'),
+        });
+
+        await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({ success: true, access_key_id: 'test-user' }),
+        });
+    });
+
+    await page.route(`${appOrigin}/admin/identities/test-user`, async (route) => {
+        await route.fulfill({
+            status: 200,
+            contentType: 'text/html',
+            body: '<!doctype html><title>Identity</title>',
+        });
+    });
+
+    await page.route(`${appOrigin}/admin/identities/new`, async (route) => {
+        await route.fulfill({
+            status: 200,
+            contentType: 'text/html',
+            body: credentialFormHtml({ edit }),
+        });
+    });
+
+    await page.goto(`${appOrigin}/admin/identities/new`);
+    return credentialRequests;
+}
+
+function collectDialogs(page) {
+    const messages = [];
+    page.on('dialog', async (dialog) => {
+        messages.push(dialog.message());
+        await dialog.accept();
+    });
+    return messages;
+}
+
+test('credential form rejects short secret keys with native validation before saving', async ({ page }) => {
+    const credentialRequests = await openCredentialForm(page);
+
+    await page.locator('#access-key-id').fill('short-secret-user');
+    await page.locator('#secret-access-key').fill('too-short');
+    await page.getByRole('button', { name: 'Save Credential' }).click();
+
+    await expect(page.locator('#secret-access-key')).toBeFocused();
+    await expect(page.locator('#secret-access-key')).toHaveJSProperty('validity.valid', false);
+    expect(credentialRequests).toEqual([]);
+});
+
+test('credential template keeps native validation without silent truncation', () => {
+    expect(credentialTemplate).toContain('<form id="credential-form">');
+    expect(credentialTemplate).toContain('minlength="40"');
+    expect(credentialTemplate).toContain('pattern=".{40}"');
+    expect(credentialTemplate).not.toContain('maxlength="40"');
+    expect(credentialTemplate).not.toContain('novalidate');
+});
+
+test('credential form rejects long secret keys with native validation instead of truncating them', async ({ page }) => {
+    const credentialRequests = await openCredentialForm(page);
+    const longSecret = 'A'.repeat(41);
+
+    await page.locator('#access-key-id').fill('long-secret-user');
+    await page.locator('#secret-access-key').fill(longSecret);
+
+    await expect(page.locator('#secret-access-key')).toHaveValue(longSecret);
+
+    await page.getByRole('button', { name: 'Save Credential' }).click();
+
+    await expect(page.locator('#secret-access-key')).toBeFocused();
+    await expect(page.locator('#secret-access-key')).toHaveJSProperty('validity.valid', false);
+    expect(credentialRequests).toEqual([]);
+});
+
+test('credential form JavaScript rejects invalid secret length if native validation is bypassed', async ({ page }) => {
+    const dialogs = collectDialogs(page);
+    const credentialRequests = await openCredentialForm(page);
+
+    await page.locator('#access-key-id').fill('js-fallback-user');
+    await page.locator('#secret-access-key').fill('too-short');
+    await page.$eval('#credential-form', (form) => {
+        form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+    });
+
+    await expect.poll(() => dialogs).toContain('Secret access key must be exactly 40 characters long');
+    expect(credentialRequests).toEqual([]);
+});
+
+test('credential form saves exactly 40 character secret keys unchanged', async ({ page }) => {
+    const dialogs = collectDialogs(page);
+    const credentialRequests = await openCredentialForm(page);
+    const validSecret = 'A'.repeat(40);
+
+    await page.locator('#access-key-id').fill('valid-secret-user');
+    await page.locator('#secret-access-key').fill(validSecret);
+    await page.getByRole('button', { name: 'Save Credential' }).click();
+
+    await expect.poll(() => dialogs).toContain('Credential saved successfully!');
+    expect(credentialRequests).toHaveLength(1);
+    expect(credentialRequests[0]).toMatchObject({
+        method: 'POST',
+        body: {
+            access_key_id: 'valid-secret-user',
+            secret_access_key: validSecret,
+        },
+    });
+    expect(credentialRequests[0].headers['x-csrf-token']).toBe('csrf-token');
+});
+
+test('credential edit form updates exactly 40 character secret keys unchanged', async ({ page }) => {
+    const dialogs = collectDialogs(page);
+    const credentialRequests = await openCredentialForm(page, { edit: true });
+    const validSecret = 'B'.repeat(40);
+
+    await page.locator('#secret-access-key').fill(validSecret);
+    await page.getByRole('button', { name: 'Save Credential' }).click();
+
+    await expect.poll(() => dialogs).toContain('Credential saved successfully!');
+    expect(credentialRequests).toHaveLength(1);
+    expect(credentialRequests[0]).toMatchObject({
+        method: 'PUT',
+        url: `${appOrigin}/admin/api/credentials/test-user`,
+        body: {
+            secret_access_key: validSecret,
+        },
+    });
+});


### PR DESCRIPTION
## Summary
- Return `400 Bad Request` for invalid secret lengths instead of treating them as server errors.
- Remove the form `maxlength` clamp so the browser enforces exact-length validation without truncating input.
- Add Rust and Playwright coverage for create/update flows and client-side validation behavior.
- Add a Playwright test script and config for the credential form suite.

## Testing
- Added unit tests covering invalid secret length handling in request handlers and error response mapping.
- Added Playwright coverage for short, long, valid, and edit-mode secret key submissions.
- Not run (not requested)